### PR TITLE
Remove rules for icmp messages already covered by conntrack

### DIFF
--- a/checks/testEmpty.nix
+++ b/checks/testEmpty.nix
@@ -44,10 +44,8 @@ machineTest ({ config, ... }: {
         }
 
         chain rule-icmp {
-          ip6 nexthdr icmpv6 icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, parameter-problem, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept
-          ip protocol icmp icmp type { destination-unreachable, router-advertisement, time-exceeded, parameter-problem } accept
-          ip6 nexthdr icmpv6 icmpv6 type echo-request accept
-          ip protocol icmp icmp type echo-request accept
+          ip6 nexthdr icmpv6 icmpv6 type { echo-request, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept
+          ip protocol icmp icmp type { echo-request, router-advertisement } accept
           ip6 saddr fe80::/10 ip6 daddr fe80::/10 udp dport 546 accept
         }
 

--- a/checks/testForward.nix
+++ b/checks/testForward.nix
@@ -77,10 +77,8 @@ machineTest ({ config, ... }: {
         }
 
         chain rule-icmp {
-          ip6 nexthdr icmpv6 icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, parameter-problem, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept
-          ip protocol icmp icmp type { destination-unreachable, router-advertisement, time-exceeded, parameter-problem } accept
-          ip6 nexthdr icmpv6 icmpv6 type echo-request accept
-          ip protocol icmp icmp type echo-request accept
+          ip6 nexthdr icmpv6 icmpv6 type { echo-request, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept
+          ip protocol icmp icmp type { echo-request, router-advertisement } accept
           ip6 saddr fe80::/10 ip6 daddr fe80::/10 udp dport 546 accept
         }
 

--- a/checks/testNat.nix
+++ b/checks/testNat.nix
@@ -53,10 +53,8 @@ machineTest ({ config, ... }: {
         }
 
         chain rule-icmp {
-          ip6 nexthdr icmpv6 icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, parameter-problem, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept
-          ip protocol icmp icmp type { destination-unreachable, router-advertisement, time-exceeded, parameter-problem } accept
-          ip6 nexthdr icmpv6 icmpv6 type echo-request accept
-          ip protocol icmp icmp type echo-request accept
+          ip6 nexthdr icmpv6 icmpv6 type { echo-request, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept
+          ip protocol icmp icmp type { echo-request, router-advertisement } accept
           ip6 saddr fe80::/10 ip6 daddr fe80::/10 udp dport 546 accept
         }
 

--- a/checks/testPortRules.nix
+++ b/checks/testPortRules.nix
@@ -66,10 +66,8 @@ machineTest ({ config, ... }: {
         }
       
         chain rule-icmp {
-          ip6 nexthdr icmpv6 icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, parameter-problem, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept
-          ip protocol icmp icmp type { destination-unreachable, router-advertisement, time-exceeded, parameter-problem } accept
-          ip6 nexthdr icmpv6 icmpv6 type echo-request accept
-          ip protocol icmp icmp type echo-request accept
+          ip6 nexthdr icmpv6 icmpv6 type { echo-request, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept
+          ip protocol icmp icmp type { echo-request, router-advertisement } accept
           ip6 saddr fe80::/10 ip6 daddr fe80::/10 udp dport 546 accept
         }
       

--- a/checks/testWebserver.nix
+++ b/checks/testWebserver.nix
@@ -52,10 +52,8 @@ machineTest ({ config, ... }: {
         }
 
         chain rule-icmp {
-          ip6 nexthdr icmpv6 icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, parameter-problem, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept
-          ip protocol icmp icmp type { destination-unreachable, router-advertisement, time-exceeded, parameter-problem } accept
-          ip6 nexthdr icmpv6 icmpv6 type echo-request accept
-          ip protocol icmp icmp type echo-request accept
+          ip6 nexthdr icmpv6 icmpv6 type { echo-request, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept
+          ip protocol icmp icmp type { echo-request, router-advertisement } accept
           ip6 saddr fe80::/10 ip6 daddr fe80::/10 udp dport 546 accept
         }
 

--- a/nftables-zoned.nix
+++ b/nftables-zoned.nix
@@ -203,10 +203,8 @@ in {
       from = "all";
       to = [ "fw" ];
       extraLines = [
-        "ip6 nexthdr icmpv6 icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, parameter-problem, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept"
-        "ip protocol icmp icmp type { destination-unreachable, router-advertisement, time-exceeded, parameter-problem } accept"
-        "ip6 nexthdr icmpv6 icmpv6 type echo-request accept"
-        "ip protocol icmp icmp type echo-request accept"
+        "ip6 nexthdr icmpv6 icmpv6 type { echo-request, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept"
+        "ip protocol icmp icmp type { echo-request, router-advertisement } accept"
         "ip6 saddr fe80::/10 ip6 daddr fe80::/10 udp dport 546 accept"
       ];
     };


### PR DESCRIPTION
Some icmp message types are covered by the conntrack rule under the `related`-category.

https://github.com/torvalds/linux/blob/c1084b6c5620a743f86947caca66d90f24060f56/net/netfilter/nf_conntrack_proto_icmp.c#L106