### PR TITLE
fix: use `cat /proc/modules` over lsmod to avoid issues with containerized environments

### DIFF
--- a/modules/nftables.nix
+++ b/modules/nftables.nix
@@ -108,7 +108,7 @@ in {
         checkScript = rulesetFile: name:
           pkgs.writeScript "nftables-${name}check" ''
             #! ${pkgs.runtimeShell} -e
-            if $(${pkgs.kmod}/bin/lsmod | grep -q ip_tables); then
+            if $(cat /proc/modules | grep -q ip_tables); then
               echo "Unload ip_tables before using nftables!" 1>&2
               exit 1
             else


### PR DESCRIPTION
I've recently tried to run this inside of a nixos container defined via

```nix
containers.example = {
  networking.nftables.firewall = # ...
};
```

but that caused a lot of error prints (although no failure) each time when the system is started:

```
Dec 19 17:53:29 ward-influxdb 19zhwn43v907d9a2pylhdbivfd6rxdni-nftables-stopcheck[440]: libkmod: kmod_module_get_holders: could not open '/sys/module/wireguard/holders': No such file or directory
Dec 19 17:53:29 ward-influxdb 19zhwn43v907d9a2pylhdbivfd6rxdni-nftables-stopcheck[440]: libkmod: kmod_module_get_holders: could not open '/sys/module/curve25519_x86_64/holders': No such file or directory
Dec 19 17:53:29 ward-influxdb 19zhwn43v907d9a2pylhdbivfd6rxdni-nftables-stopcheck[440]: libkmod: kmod_module_get_holders: could not open '/sys/module/libchacha20poly1305/holders': No such file or directory
Dec 19 17:53:29 ward-influxdb 19zhwn43v907d9a2pylhdbivfd6rxdni-nftables-stopcheck[440]: libkmod: kmod_module_get_holders: could not open '/sys/module/chacha_x86_64/holders': No such file or directory
Dec 19 17:53:29 ward-influxdb 19zhwn43v907d9a2pylhdbivfd6rxdni-nftables-stopcheck[440]: libkmod: kmod_module_get_holders: could not open '/sys/module/poly1305_x86_64/holders': No such file or directory
[~300 more lines skipped]
```

This is because in systemd-nspawn containers like the ones nixos creates here, only a subset of `/sys` will be mounted by default. This causes those errors in reference count resolution in `lsmod` [related issue](https://github.com/kmod-project/kmod/issues/10) which spams the syslog. A simple alternative is to just use `cat /proc/modules` to check for ip_tables, which is available for normal systems and for containers.