### PR TITLE
Add missing builtins.length check to nnf-default-stopRuleset.nix

### DIFF
--- a/modules/snippets/nnf-default-stopRuleset.nix
+++ b/modules/snippets/nnf-default-stopRuleset.nix
@@ -49,7 +49,7 @@ in
               ip protocol icmp icmp type echo-request accept
 
               # accept SSH connections (required for a server)
-              ${optionalString (ports > 0) "tcp dport ${toPortList ports} accept"}
+              ${optionalString (length ports > 0) "tcp dport ${toPortList ports} accept"}
 
               # count and drop any other traffic
               counter drop


### PR DESCRIPTION
Currently, when I use `nixos-nftables-firewall` an just enable the `nnf-common` snippets, I get the following error:

![image](https://github.com/thelegy/nixos-nftables-firewall/assets/38051499/03dfb51e-2872-4b1a-b318-8d5c22c6dbd5)

This PR adds the missing `length` check in the `nnf-default-stopRuleset.nix` file which I believe will fix the issue.
