### PR TITLE
Fix missing support for nixos firewall port ranges

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -22,5 +22,7 @@ in
       testInheritance = import ./testInheritance.nix lib;
 
       testRuleType = import ./testRuleType.nix lib;
+
+      testNixosFirewall = import ./testNixosFirewall.nix lib;
     };
   }

--- a/checks/testNixosFirewall.nix
+++ b/checks/testNixosFirewall.nix
@@ -1,0 +1,54 @@
+{
+  machineTest,
+  flakes,
+  ...
+}:
+machineTest ({config, ...}: {
+  imports = [flakes.self.nixosModules.default];
+
+  networking.nftables.firewall = {
+    enable = true;
+    snippets.nnf-common.enable = false;
+    snippets.nnf-nixos-firewall.enable = true;
+  };
+
+  networking.firewall.allowedTCPPorts = [22];
+  networking.firewall.allowedTCPPortRanges = [
+    { from = 80; to = 90; }
+  ];
+  networking.firewall.allowedUDPPorts = [220];
+  networking.firewall.allowedUDPPortRanges = [
+    { from = 32768; to = 60999; }
+  ];
+
+  output = {
+    expr = config.networking.nftables.ruleset;
+    expected = ''
+      table inet firewall {
+
+        chain forward {
+          type filter hook forward priority 0; policy drop;
+        }
+      
+        chain input {
+          type filter hook input priority 0; policy drop
+          jump rule-nixos-firewall
+        }
+      
+        chain postrouting {
+          type nat hook postrouting priority srcnat;
+        }
+      
+        chain prerouting {
+          type nat hook prerouting priority dstnat;
+        }
+
+        chain rule-nixos-firewall {
+          tcp dport { 22, 80-90 } accept
+          udp dport { 220, 32768-60999 } accept
+        }
+
+      }
+    '';
+  };
+})

--- a/modules/snippets/nnf-nixos-firewall.nix
+++ b/modules/snippets/nnf-nixos-firewall.nix
@@ -18,7 +18,9 @@ in
         from = mkDefault "all";
         to = [localZoneName];
         allowedTCPPorts = config.networking.firewall.allowedTCPPorts;
+        allowedTCPPortRanges = config.networking.firewall.allowedTCPPortRanges;
         allowedUDPPorts = config.networking.firewall.allowedUDPPorts;
+        allowedUDPPortRanges = config.networking.firewall.allowedUDPPortRanges;
         ignoreEmptyRule = true;
       };
     };


### PR DESCRIPTION
Thank you for the well-structured module!

Today I discovered that the nixos-firewall snippet ignores port ranges. This PR should fix this.