### PR TITLE
add support for sets

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -22,5 +22,7 @@ in
       testInheritance = import ./testInheritance.nix lib;
 
       testRuleType = import ./testRuleType.nix lib;
+
+      testSets = import ./testSets.nix lib;
     };
   }

--- a/checks/testChains.nix
+++ b/checks/testChains.nix
@@ -63,7 +63,7 @@ machineTest ({config, ...}: {
   };
 
   output = {
-    expr = config.build.nftables-chains.ruleset;
+    expr = config.networking.nftables.ruleset;
     expected = ''
       table inet firewall {
 

--- a/checks/testSets.nix
+++ b/checks/testSets.nix
@@ -1,0 +1,47 @@
+{
+  machineTest,
+  flakes,
+  ...
+}:
+machineTest ({config, ...}: {
+  imports = [flakes.self.nixosModules.ruleset];
+
+  networking.nftables = {
+    sets.banlist = {
+      type = "ipv4_addr";
+      flags = ["dynamic" "timeout"];
+      elements = [
+        "8.8.8.8"
+      ];
+      timeout = "24h";
+    };
+    sets.whitelist = {
+      typeof = "ip saddr";
+      flags = ["constant"];
+      elements = [
+        "192.168.1.234"
+      ];
+    };
+  };
+
+  output = {
+    expr = config.networking.nftables.ruleset;
+    expected = ''
+      table inet firewall {
+
+        set banlist {
+          type ipv4_addr;
+          flags dynamic, timeout;
+          elements = {8.8.8.8};
+        }
+
+        set whitelist {
+          typeof ip saddr;
+          flags constant;
+          elements = {192.168.1.234};
+        }
+
+      }
+    '';
+  };
+})

--- a/docs/sets.md
+++ b/docs/sets.md
@@ -1,0 +1,4 @@
+# Sets
+
+## Options
+%networking.nftables.sets%

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,8 @@
       chains = module ./modules/chains.nix;
       zoned = module ./modules/zoned.nix;
       snippets = module ./modules/snippets.nix;
+      sets = module ./modules/sets.nix;
+      ruleset = module ./modules/ruleset.nix;
 
       default = snippets;
 

--- a/modules/chains.nix
+++ b/modules/chains.nix
@@ -1,4 +1,4 @@
-flakes @ {dependencyDagOfSubmodule, ...}: {
+{dependencyDagOfSubmodule, ...}: {
   lib,
   config,
   ...
@@ -111,10 +111,6 @@ with dependencyDagOfSubmodule.lib.bake lib; let
     };
   };
 in {
-  imports = [
-    flakes.self.nixosModules.nftables
-  ];
-
   options = {
     networking.nftables.chains = mkOption {
       type = types.attrsOf chainType;
@@ -167,16 +163,5 @@ in {
       naturalSort
       (map (x: renderedChains.${x}))
     ];
-
-    ruleset = ''
-      table inet firewall {
-      ${concatMapStrings (x: "\n${x}\n") requiredChains}
-      }
-    '';
   };
-
-  config.networking.nftables.ruleset = let
-    inherit (config.build.nftables-chains) requiredChains ruleset;
-  in
-    mkIf (length requiredChains > 0) ruleset;
 }

--- a/modules/ruleset.nix
+++ b/modules/ruleset.nix
@@ -1,0 +1,23 @@
+flakes @ {...}: {
+  lib,
+  config,
+  ...
+}:
+with lib; {
+  imports = [
+    flakes.self.nixosModules.nftables
+    flakes.self.nixosModules.sets
+    flakes.self.nixosModules.chains
+  ];
+  config.networking.nftables.ruleset = let
+    requiredChains = config.build.nftables-chains.requiredChains;
+    sets = config.build.nftables-sets;
+    merged =
+      sets
+      ++ requiredChains;
+  in ''
+    table inet firewall {
+    ${concatMapStrings (x: "\n${x}\n") merged}
+    }
+  '';
+}

--- a/modules/sets.nix
+++ b/modules/sets.nix
@@ -1,0 +1,127 @@
+{...}: {
+  lib,
+  config,
+  ...
+}:
+with lib; let
+  setType = types.submodule {
+    options = {
+      type = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = mdDoc ''
+          The data type contained in the set. Either 'type' or 'typeof' is required.
+        '';
+        # the nftables wiki doesn't seam to have the full list of types, so we'll just use types.str for now
+        # below is a list of types that I'm aware of
+        /*
+           type = types.enum [
+          "ipv4_addr"
+          "ipv6_addr"
+          "ether_addr"
+          "inet_proto"
+          "inet_service"
+          "mark"
+          "ifname"
+          "iface_index"
+        ];
+        */
+      };
+      typeof = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = mdDoc ''
+          Data type determined from an expression. For example, 'typeof ip saddr' instead of 'type ipv4_addr'.
+          Either 'type' or 'typeof' is required.
+        '';
+      };
+      flags = mkOption {
+        type = types.listOf (types.enum [
+          "constant"
+          "dynamic"
+          "interval"
+          "timeout"
+        ]);
+        default = ["dynamic"];
+        description = mdDoc ''
+          Features to enable on the set.
+          Dynamic is enabled by default.
+        '';
+      };
+      autoMerge = mkOption {
+        type = types.bool;
+        default = false;
+        description = mdDoc ''
+          Automaticly merge adjacent/overlapping set elements. This is only valid for interval sets.
+        '';
+      };
+      elements = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = mdDoc ''
+          The list of elements that the set will start with.
+        '';
+      };
+      timeout = mkOption {
+        type = types.listOf types.str;
+        default = "";
+        description = mdDoc ''
+          Timeout determines how long an element will stay in the set. In order to use, the 'timeout' flag needs to be set.
+        '';
+      };
+    };
+  };
+in {
+  options = {
+    networking.nftables.sets = mkOption {
+      type = types.attrsOf setType;
+      default = {};
+    };
+
+    build.nftables-sets = mkOption {
+      type = types.listOf types.str;
+      internal = true;
+    };
+  };
+
+  config.assertions = let
+    sets = config.networking.nftables.sets;
+  in
+    flatten (attrsets.mapAttrsToList (name: set: [
+        {
+          assertion = (set.type != null) || (set.typeof != null);
+          message = "nftables set '${name}' must have either 'type' or 'typeof' configured.";
+        }
+      ])
+      sets);
+
+  config.build.nftables-sets = let
+    renderSet = name: set: let
+      type =
+        if set.type != null
+        then ["type ${set.type};"]
+        else if set.typeof != null
+        then ["typeof ${set.typeof};"]
+        else [];
+      flags =
+        if length set.flags > 0
+        then ["flags ${concatStringsSep ", " set.flags};"]
+        else [];
+      autoMerge =
+        if set.autoMerge
+        then ["auto-merge"]
+        else [];
+      elements =
+        if length set.elements > 0
+        then ["elements = {${concatStringsSep ", " set.elements}};"]
+        else [];
+      allLines =
+        type
+        ++ flags
+        ++ autoMerge
+        ++ elements;
+      lines = lists.remove "" allLines;
+    in "  set ${name} {\n${concatMapStrings (l: "    ${l}\n") lines}  }";
+  in
+    attrsets.mapAttrsToList renderSet config.networking.nftables.sets;
+}

--- a/modules/zoned.nix
+++ b/modules/zoned.nix
@@ -8,7 +8,7 @@ with dependencyDagOfSubmodule.lib.bake lib; let
   ruleTypes = ["ban" "rule" "policy"];
 in {
   imports = [
-    flakes.self.nixosModules.chains
+    flakes.self.nixosModules.ruleset
   ];
 
   options.networking.nftables.firewall = {


### PR DESCRIPTION
In order to make this change, I've had to move the final ruleset generation from chains.nix to a new module.
In doing so I had to change where testChains.nix is expecting the output from 'config.build.nftables-chains.ruleset' to 'config.networking.nftables.ruleset'. Apart from this no other existing tests were touched.

I decided to make this addition because systemd-networkd allows us to dynamically add ip addresses or interface names to sets. Additionally, this PR will resolve issue #21.

Please let me know if anything needs to be changed.